### PR TITLE
Refactored for new webcoin module APIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,87 +1,107 @@
-var mapStream = require('map-stream')
 var assert = require('assert')
+var EventEmitter = require('events')
+var address = require('bitcoinjs-lib').address
+var script = require('bitcoinjs-lib').script
+var inherits = require('inherits')
+var mapStream = require('map-stream')
 var debug = require('debug')('burnie')
 
 function Burnie (opts) {
   if (!(this instanceof Burnie)) return new Burnie(opts)
 
-  assert(typeof opts.from !== 'undefined')
-  assert(Buffer.isBuffer(opts.pubkeyHash))
+  assert(typeof opts.peers !== 'undefined')
+  assert(typeof opts.chain !== 'undefined')
+  assert(typeof opts.from === 'number')
+  assert(typeof opts.address === 'string')
 
-  debug('new burnie', opts.pubkeyHash.toString('hex'), opts.from)
+  EventEmitter.call(this)
+
+  debug('new burnie', opts.address, opts.from)
 
   var self = this
 
-  this.node = opts.node
-  this.pubkeyHash = opts.pubkeyHash
+  this.peers = opts.peers
+  this.chain = opts.chain
+  this.from = opts.from
+  this.address = opts.address
+  this.pubkeyHash = address.fromBase58Check(this.address).hash
+  this.filtered = opts.filtered != null ? opts.filtered : true
 
-  this.node.filter.insert(opts.pubkeyHash)
-
-  this.node.on('error', function (err) {
-    // TODO handle this better
-    throw err
+  this.peers.on('error', function (err) {
+    self.emit('error', err)
   })
 
-  this.stream = mapStream(function (tx, callback) {
-    debug('checking tx', tx.transaction.hash)
-    var outputs = []
-    tx.transaction.outputs.forEach(function (output, o) {
-      // Ignore outputs that aren't pay-to-pubkey-hash
-      if (!output.script.isPublicKeyHashOut()) {
-        debug('ignoring non-pay-to-pubkey-hash output', o)
-        return
-      }
+  this.stream = mapStream(this.onTransaction.bind(this))
+  self.txStream = self.peers.createTransactionStream({ filtered: self.filtered })
+  self.txStream.pipe(self.stream)
 
-      // Ignore outputs to the wrong address
-      var payToHash = output.script.getAddressInfo().hashBuffer
-      if (!payToHash.equals(self.pubkeyHash)) {
-        debug('ignoring output w/ payment to', o, payToHash)
-        return
-      }
-
-      debug('valid output found', o)
-      outputs.push({
-        tx: tx,
-        satoshis: output.satoshis,
-        blockHeight: tx.block.height,
-        time: tx.block.header.time
-      })
-    })
-
-    if (outputs.length === 0) {
-      debug('no valid outputs, ignoring')
-      callback()
-    } else if (outputs.length > 1) {
-      debug('multiple valid outputs, ignoring')
-      callback()
-    } else {
-      assert.equal(outputs.length, 1)
-      callback(null, outputs[0])
-    }
-  })
-
-  var start = function () {
-    debug('burnie starting...')
-    self.txStream = self.node.createTransactionStream({ from: opts.from })
-    self.txStream.pipe(self.stream)
-  }
-
-  self.node.peers.once('peer', function (peer) {
-    if (self.node.chain.tip.height >= opts.from) {
-      start()
+  // TODO: get webcoin API to handle this for us
+  self.peers.once('peer', function (peer) {
+    if (self.chain.tip.height >= opts.from) {
+      self.start()
     } else {
       var onSync = function (tip) {
         if (tip.height >= opts.from) {
-          self.node.chain.removeListener('sync', onSync)
-          start()
+          self.chain.removeListener('block', onSync)
+          self.start()
         }
       }
-      self.node.chain.on('sync', onSync)
+      self.chain.on('block', onSync)
     }
   })
-  self.node.chain.on('sync', function (tip) {
-    debug('headers at', tip.height)
+}
+inherits(Burnie, EventEmitter)
+
+Burnie.prototype.start = function () {
+  var self = this
+  debug('burnie starting...')
+  this.chain.getBlockAtHeight(this.from, function (err, block) {
+    if (err) return self.emit('error', err)
+    self.chain.createReadStream({ from: block.header.getHash() }).pipe(self.txStream)
   })
+}
+
+Burnie.prototype.onTransaction = function (tx, callback) {
+  debug('checking tx', tx.transaction.getId())
+  var outputs = []
+  var self = this
+  tx.transaction.outs.forEach(function (output, o) {
+    // Ignore outputs that aren't pay-to-pubkey-hash
+    if (!script.isPubKeyHashOutput(output.script)) {
+      debug('ignoring non-pay-to-pubkey-hash output', o)
+      return
+    }
+
+    // Ignore outputs to the wrong address
+    var payToAddress = address.fromOutputScript(output.script)
+    if (payToAddress !== self.address) {
+      debug('ignoring output w/ payment to', o, payToAddress)
+      return
+    }
+
+    debug('valid output found', o, output)
+    outputs.push({
+      tx: tx,
+      satoshis: output.value,
+      blockHeight: tx.block.height,
+      time: tx.block.header.timestamp
+    })
+  })
+
+  if (outputs.length === 0) {
+    debug('no valid outputs, ignoring')
+    callback()
+  } else if (outputs.length > 1) {
+    debug('multiple valid outputs, ignoring')
+    callback()
+  } else {
+    assert.equal(outputs.length, 1)
+    callback(null, outputs[0])
+  }
+}
+
+Burnie.prototype.filterElements = function () {
+  return [ this.pubkeyHash ]
 }
 
 module.exports = Burnie

--- a/package.json
+++ b/package.json
@@ -13,10 +13,16 @@
     "standard": "^5.4.1"
   },
   "dependencies": {
+    "bitcoin-filter": "^0.0.2",
+    "bitcoin-net": "^3.1.0",
+    "bitcoinjs-lib": "^2.2.0",
+    "blockchain-spv": "^1.2.1",
     "debug": "^2.2.0",
-    "map-stream": "0.0.6",
-    "webcoin": "^1.0.2",
-    "webcoin-bitcoin": "^0.2.2"
+    "inherits": "^2.0.1",
+    "levelup": "^1.3.1",
+    "map-stream": "0.0.x",
+    "memdown": "^1.1.2",
+    "webcoin-bitcoin": "^2.1.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I updated the code to work with the newest versions of the webcoin modules.

Note that this doesn't depend on the `webcoin` package itself, as the API for that still needs to be worked out (it will basically just provide some boilerplate code to glue together the stuff in the other modules, such as [`blockchain-spv`](https://github.com/mappum/blockchain-spv) and [`bitcoin-net`](https://github.com/mappum/bitcoin-net)). The goal is to prevent consumers from having to do most of the stuff that right now is in `example.js` in this repo.

I'd very much appreciate your feedback on the APIs here. While working on this I saw how you sometimes had to hack around the limitations of webcoin (e.g. to provide a custom checkpoint you had to modify the built-in constants).
